### PR TITLE
ci: fix expression & wire PUBLIC_URL for optional public smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 env:
   PUBLIC_URL: ${{ vars.PUBLIC_URL }}
@@ -108,24 +109,6 @@ jobs:
             init.json
             session.txt
 
-  smoke-public:
-    runs-on: ubuntu-latest
-    needs: build
-    if: ${{ env.PUBLIC_URL != '' }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-      - run: npm ci || npm install
-      - name: Public smoke
-        env:
-          PUBLIC_URL: ${{ env.PUBLIC_URL }}
-        run: |
-          set -euo pipefail
-          bash scripts/smoke-public.sh "$PUBLIC_URL"
-
   smoke-canvas:
     runs-on: ubuntu-latest
     needs: build
@@ -201,10 +184,18 @@ jobs:
             server.log
             init.json
 
-  smoke_public:
-    if: ${{ vars.PUBLIC_MCP_URL != '' }}
+  public_smoke:
     runs-on: ubuntu-latest
+    needs: build
+    if: ${{ env.PUBLIC_URL != '' }}
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get update && sudo apt-get install -y jq
-      - run: bash scripts/smoke-public.sh "${{ vars.PUBLIC_MCP_URL }}"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci || npm install
+      - name: Public smoke
+        env:
+          PUBLIC_BASE: ${{ env.PUBLIC_URL }}
+        run: bash scripts/smoke-public.sh


### PR DESCRIPTION
Adds workflow_dispatch; keeps PUBLIC_URL in top-level env; replaces legacy public smoke with optional public_smoke job that runs after build and calls scripts/smoke-public.sh using PUBLIC_URL.