### PR TITLE
ci: public_smoke via workflow_dispatch input (no repo var)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: CI
 on:
   push:
   pull_request:
-
-env:
-  PUBLIC_URL: ${{ vars.PUBLIC_URL }}
+  workflow_dispatch:
+    inputs:
+      PUBLIC_URL:
+        description: 'Base URL (e.g., https://<ngrok>.ngrok-free.dev)'
+        required: true
+        type: string
 
 jobs:
   build:
@@ -201,10 +204,18 @@ jobs:
             server.log
             init.json
 
-  smoke_public:
-    if: ${{ vars.PUBLIC_MCP_URL != '' }}
+  public_smoke:
     runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.PUBLIC_URL != '' }}
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get update && sudo apt-get install -y jq
-      - run: bash scripts/smoke-public.sh "${{ vars.PUBLIC_MCP_URL }}"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci || npm install
+      - name: Public smoke
+        env:
+          PUBLIC_BASE: ${{ inputs.PUBLIC_URL }}
+        run: bash scripts/smoke-public.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,10 @@ jobs:
             init.json
             session.txt
 
-  public_smoke:
+  smoke-public:
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.PUBLIC_URL != '' }}
+    if: ${{ env.PUBLIC_URL != '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -124,8 +124,10 @@ jobs:
       - run: npm ci || npm install
       - name: Public smoke
         env:
-          PUBLIC_BASE: ${{ inputs.PUBLIC_URL }}
-        run: bash scripts/smoke-public.sh
+          PUBLIC_URL: ${{ env.PUBLIC_URL }}
+        run: |
+          set -euo pipefail
+          bash scripts/smoke-public.sh "$PUBLIC_URL"
 
   smoke-canvas:
     runs-on: ubuntu-latest
@@ -205,7 +207,7 @@ jobs:
   public_smoke:
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.PUBLIC_URL != '' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.PUBLIC_URL != '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -215,5 +217,5 @@ jobs:
       - run: npm ci || npm install
       - name: Public smoke
         env:
-          PUBLIC_BASE: ${{ inputs.PUBLIC_URL }}
+          PUBLIC_BASE: ${{ github.event.inputs.PUBLIC_URL }}
         run: bash scripts/smoke-public.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,10 @@ jobs:
             init.json
             session.txt
 
-  smoke-public:
+  public_smoke:
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ env.PUBLIC_URL != '' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.PUBLIC_URL != '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -124,10 +124,8 @@ jobs:
       - run: npm ci || npm install
       - name: Public smoke
         env:
-          PUBLIC_URL: ${{ env.PUBLIC_URL }}
-        run: |
-          set -euo pipefail
-          bash scripts/smoke-public.sh "$PUBLIC_URL"
+          PUBLIC_BASE: ${{ inputs.PUBLIC_URL }}
+        run: bash scripts/smoke-public.sh
 
   smoke-canvas:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a PUBLIC_URL input to workflow_dispatch so manual runs can supply an ngrok base
- remove reliance on repo-level PUBLIC_URL and gate public_smoke on manual dispatch with that input

## Testing
- not run (workflow change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - CI now supports manual runs with a required PUBLIC_URL input for targeted public smoke checks.
  - Public smoke tests only run on manual trigger when a non-empty PUBLIC_URL is provided.
  - Removed legacy system package installation; smoke job relies on Node.js/npm setup with caching.
  - Public smoke job now reads the URL from the workflow input; core smoke steps remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->