### PR TITLE
fix: stabilize MCP session lifecycle and graceful shutdown

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -591,7 +591,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
       if (sessionId) {
         res.status(401).json({
           jsonrpc: '2.0',
-          error: { code: -32000, message: 'Invalid or missing session ID' },
+          error: { code: -32000, message: 'Invalid session ID' },
           id: requestId,
         });
         return;
@@ -719,9 +719,11 @@ app.get('/mcp', async (req: Request, res: Response) => {
     entry = getActiveSession(sessionId);
   }
   if (!entry) {
-    res.status(400).json({
+    const status = sessionId ? 401 : 400;
+    const message = sessionId ? 'Invalid session ID' : 'Missing session ID';
+    res.status(status).json({
       jsonrpc: '2.0',
-      error: { code: -32000, message: 'Invalid or missing session ID' },
+      error: { code: -32000, message },
       id: null,
     });
     return;
@@ -746,9 +748,11 @@ app.delete('/mcp', async (req: Request, res: Response) => {
     entry = getActiveSession(sessionId);
   }
   if (!entry) {
-    res.status(400).json({
+    const status = sessionId ? 401 : 400;
+    const message = sessionId ? 'Invalid session ID' : 'Missing session ID';
+    res.status(status).json({
       jsonrpc: '2.0',
-      error: { code: -32000, message: 'Invalid or missing session ID' },
+      error: { code: -32000, message },
       id: null,
     });
     return;

--- a/src/http.ts
+++ b/src/http.ts
@@ -589,7 +589,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
 
     if (!existing) {
       if (sessionId) {
-        res.status(200).json({
+        res.status(401).json({
           jsonrpc: '2.0',
           error: { code: -32000, message: 'Invalid or missing session ID' },
           id: requestId,

--- a/src/smoke.local.ts
+++ b/src/smoke.local.ts
@@ -89,7 +89,7 @@ const ci = (msg: string) => console.log(msg);
     .set('Mcp-Session-Id', sessionId)
     .send({ jsonrpc: '2.0', id: 99, method: 'tools/list', params: {} });
   const afterMessage = after.body?.error?.message ?? '';
-  afterOk = after.status === 200 && /invalid or missing session id/i.test(afterMessage);
+  afterOk = after.status === 401 && /invalid or missing session id/i.test(afterMessage);
   if (!afterOk) pass = false;
   console.log({ status: after.status, body: after.body });
 

--- a/src/smoke.local.ts
+++ b/src/smoke.local.ts
@@ -18,7 +18,10 @@ const ci = (msg: string) => console.log(msg);
   let listOk = false;
   let echoOk = false;
   let badOk = false;
+  let getMissingOk = false;
+  let getInvalidOk = false;
   let delOk = false;
+  let deleteInvalidOk = false;
   let afterOk = false;
 
   ci('### /healthz');
@@ -26,6 +29,13 @@ const ci = (msg: string) => console.log(msg);
   healthOk = health.status === 200 && typeof health.body === 'object';
   if (!healthOk) pass = false;
   console.log({ status: health.status, body: health.body });
+
+  ci('### GET /mcp (missing session)');
+  const getMissing = await request(app).get('/mcp');
+  const missingMessage = getMissing.body?.error?.message ?? '';
+  getMissingOk = getMissing.status === 400 && /missing session id/i.test(missingMessage);
+  if (!getMissingOk) pass = false;
+  console.log({ status: getMissing.status, body: getMissing.body });
 
   ci('### initialize');
   const init = await request(app)
@@ -75,11 +85,29 @@ const ci = (msg: string) => console.log(msg);
   if (!badOk) pass = false;
   console.log({ status: bad.status, body: bad.body });
 
+  ci('### GET /mcp (invalid session)');
+  const getInvalid = await request(app)
+    .get('/mcp')
+    .set('Mcp-Session-Id', `${sessionId}-invalid`);
+  const invalidGetMessage = getInvalid.body?.error?.message ?? '';
+  getInvalidOk = getInvalid.status === 401 && /invalid session id/i.test(invalidGetMessage);
+  if (!getInvalidOk) pass = false;
+  console.log({ status: getInvalid.status, body: getInvalid.body });
+
   ci('### DELETE /mcp');
   const del = await request(app).delete('/mcp').set('Mcp-Session-Id', sessionId);
   delOk = del.status === 204;
   if (!delOk) pass = false;
   console.log({ status: del.status });
+
+  ci('### DELETE /mcp (invalid session)');
+  const deleteInvalid = await request(app)
+    .delete('/mcp')
+    .set('Mcp-Session-Id', `${sessionId}-invalid`);
+  const invalidDeleteMessage = deleteInvalid.body?.error?.message ?? '';
+  deleteInvalidOk = deleteInvalid.status === 401 && /invalid session id/i.test(invalidDeleteMessage);
+  if (!deleteInvalidOk) pass = false;
+  console.log({ status: deleteInvalid.status, body: deleteInvalid.body });
 
   ci('### tools/list after delete (should error)');
   const after = await request(app)
@@ -89,12 +117,23 @@ const ci = (msg: string) => console.log(msg);
     .set('Mcp-Session-Id', sessionId)
     .send({ jsonrpc: '2.0', id: 99, method: 'tools/list', params: {} });
   const afterMessage = after.body?.error?.message ?? '';
-  afterOk = after.status === 401 && /invalid or missing session id/i.test(afterMessage);
+  afterOk = after.status === 401 && /invalid session id/i.test(afterMessage);
   if (!afterOk) pass = false;
   console.log({ status: after.status, body: after.body });
 
   console.log('\n=== SUMMARY ===');
-  console.log({ healthOk, initOk, listOk, echoOk, badOk, delOk, afterOk });
+  console.log({
+    healthOk,
+    getMissingOk,
+    initOk,
+    listOk,
+    echoOk,
+    badOk,
+    getInvalidOk,
+    delOk,
+    deleteInvalidOk,
+    afterOk,
+  });
 
   process.exit(pass ? 0 : 1);
 })().catch((err) => {


### PR DESCRIPTION
## Summary
- make session eviction atomic by checking existing mapping before closing
- guard concurrent initialize flows with pending session tracking and pre-generated IDs
- add graceful shutdown hooks to stop the server and close transports

## Testing
- npm run typecheck
- npm run build
- npm run smoke:local

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Graceful server shutdown on SIGINT/SIGTERM, returning 503 during shutdown and ensuring active requests and sessions close cleanly.
  - Requests wait for any in-progress session setup for the same session ID before proceeding.
  - Session initialization is guarded with per-session pending tracking to prevent concurrent setups and ensure cleanup on failure.

- Bug Fixes
  - Fixed race conditions during session init/teardown to avoid duplicate or stale sessions.
  - Synchronized GET/POST/DELETE flows and TTL checks to prevent conflicts and resource leaks.
  - Invalid or missing sessions now return 401 rather than 200/400.

- Tests
  - Added tests covering GET/DELETE behavior for missing/invalid sessions and updated validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->