### PR TITLE
sec: lock down /_debug/sessions, clarify CORS, add rate limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "2.8.5",
         "dotenv": "16.4.5",
         "express": "4.19.2",
+        "express-rate-limit": "^8.1.0",
         "zod": "3.25.8"
       },
       "devDependencies": {
@@ -642,6 +643,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
@@ -1957,10 +1973,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.1.0.tgz",
+      "integrity": "sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -2261,6 +2280,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "cors": "2.8.5",
         "dotenv": "16.4.5",
         "express": "4.19.2",
-        "express-rate-limit": "^8.1.0",
+        "express-rate-limit": "8.1.0",
         "zod": "3.25.8"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cors": "2.8.5",
     "dotenv": "16.4.5",
     "express": "4.19.2",
-    "express-rate-limit": "^8.1.0",
+    "express-rate-limit": "8.1.0",
     "zod": "3.25.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,17 +18,18 @@
     "cors": "2.8.5",
     "dotenv": "16.4.5",
     "express": "4.19.2",
+    "express-rate-limit": "^8.1.0",
     "zod": "3.25.8"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "4.17.21",
     "@types/node": "20.14.12",
+    "@types/supertest": "^2.0.16",
     "supertest": "^7.1.3",
     "tsx": "4.19.2",
     "typescript": "5.5.4",
-    "vitest": "2.0.5",
-    "@types/supertest": "^2.0.16"
+    "vitest": "2.0.5"
   },
   "engines": {
     "node": ">=20.10.0"

--- a/src/http.ts
+++ b/src/http.ts
@@ -868,8 +868,6 @@ app.delete('/mcp', async (req: Request, res: Response) => {
   res.status(204).end();
 });
 
-app.use(jsonParseErrorHandler);
-
 const PORT = Number(process.env.PORT ?? '8787');
 const SHOULD_LISTEN = process.env.DISABLE_HTTP_LISTEN !== '1';
 


### PR DESCRIPTION
## Summary
- require a matching X-Debug-Token in production before exposing /_debug/sessions and redact server-side details when enabled
- refine CORS handling for no-origin requests and fail closed when the allowlist is empty or the origin is unapproved
- add express-rate-limit guards for all /mcp traffic plus a tighter tools/call session limiter with JSON-RPC 429 responses

## Testing
- npm run typecheck
- npm run build
- npm run smoke:local
- DISABLE_HTTP_LISTEN=1 node --import tsx/esm (supertest burst to confirm 429 response)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Global and per-action rate limiting to reduce abuse; callers receive structured error responses when limits are hit.
  - Improved session lifecycle and initialization for more reliable request handling; session TTL behavior preserved.

- Refactor
  - Stricter cross-origin request handling and unified error responses for consistency.
  - Debug sessions endpoint restricted in production and session identifiers obscured.

- Chores
  - Added a runtime rate-limiting dependency; removed an unused development typing dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->