### PR TITLE
fix: use sanitized Canvas token for Authorization everywhere

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -351,8 +351,8 @@ const createServer = () => {
     (args) => {
       EnvCheckInput.parse(args ?? {});
       const summary = {
-        hasCanvasBaseUrl: Boolean(process.env.CANVAS_BASE_URL),
-        hasCanvasToken: Boolean(process.env.CANVAS_TOKEN),
+        hasCanvasBaseUrl: Boolean(CANVAS_BASE_URL),
+        hasCanvasToken: Boolean(CANVAS_TOKEN),
       };
       return {
         content: [{ type: 'text', text: JSON.stringify(summary) }],

--- a/tests/canvas-token-sanitize.test.ts
+++ b/tests/canvas-token-sanitize.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import axios, { AxiosHeaders } from 'axios';
+
+const ORIGINAL_ENV = { ...process.env };
+
+const loadServer = async () => {
+  await import('../src/http');
+};
+
+describe('Canvas token sanitization', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key];
+    }
+    Object.assign(process.env, ORIGINAL_ENV);
+    process.env.CANVAS_BASE_URL = 'https://example.instructure.com';
+    process.env.CANVAS_TOKEN = '  abc123\n';
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in ORIGINAL_ENV)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, ORIGINAL_ENV);
+  });
+
+  it('uses trimmed CANVAS_TOKEN when building Authorization headers', async () => {
+    let capturedConfig: any;
+    vi.spyOn(axios, 'create').mockImplementation((config?: any) => {
+      capturedConfig = config;
+      return {
+        defaults: { headers: config?.headers ?? undefined },
+        get: vi.fn(),
+      } as any;
+    });
+
+    await loadServer();
+
+    expect(capturedConfig).toBeTruthy();
+    const headers = capturedConfig?.headers as AxiosHeaders | Record<string, any> | undefined;
+    const authHeader =
+      (headers as AxiosHeaders | undefined)?.get?.('Authorization') ??
+      (headers as AxiosHeaders | undefined)?.get?.('authorization') ??
+      (headers as AxiosHeaders | undefined)?.get?.('AUTHORIZATION') ??
+      (headers as Record<string, any> | undefined)?.Authorization ??
+      (headers as Record<string, any> | undefined)?.authorization;
+    expect(authHeader).toBe('Bearer abc123');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure every Canvas Authorization header and auth gate relies on the trimmed CANVAS_TOKEN constant
- add a regression test that covers tokens with trailing whitespace/newlines

## Testing
- npm run typecheck
- npm run build
- npm test
- local smoke (init → tools/list → echo)

### Smoke output
```
{"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{"listChanged":true}},"serverInfo":{"name":"sanity-mcp","version":"0.1.0"}},"jsonrpc":"2.0","id":1}
Session: 2a368d3c-e5ec-4c2c-a122-2795d46efbd3
{"result":{"tools":[{"name":"echo","title":"Echo","description":"Returns the text you send","inputSchema":{"type":"object","properties":{"text":{"type":"string","description":"text to echo"}},"required":["text"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}},{"name":"env_check","title":"Env check","description":"Reports if Canvas env vars are present (no secrets returned)","inputSchema":{"type":"object","properties":{},"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}}]},"jsonrpc":"2.0","id":2}
{"result":{"content":[{"type":"text","text":"hello"}]},"jsonrpc":"2.0","id":3}
```

@coderabbitai


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trimmed whitespace/newlines from the Canvas access token to prevent authentication failures.

* **Refactor**
  * Configuration checks now source Canvas settings from the app’s centralized constants instead of directly from environment variables, which may change how Canvas presence is reported.

* **Tests**
  * Added tests to verify the token is sanitized and applied to request headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->