### PR TITLE
ocr-webhook: base64 O(n); sanitized error payloads; worker error guards; large PDF preslice test

### DIFF
--- a/services/ocr-webhook/README.md
+++ b/services/ocr-webhook/README.md
@@ -158,8 +158,18 @@ export OCR_TIMEOUT_MS=20000
 - **Azure polling**: The poller treats non-200 HTTP responses as errors. On 429/5xx, it retries honoring `Retry-After` headers (HTTP-date or seconds) with clamping to `[AZURE_POLL_MS, AZURE_RETRY_MAX_MS]`. Other 4xx statuses fail fast. Long timeouts surface a 504 with `code:"azure_timeout"`.
 - **Timeout semantics**: Both engines return **504** on timeout (Azure uses `code:"azure_timeout"`; OpenAI reports `message:"OpenAI OCR timed out"`).
 - **Error responses**: All errors include `{ error: { code: string, httpStatus: number, message: string, ...extra } }` format.
+- **Error sanitizer knobs**: See “Error payload size knobs (optional)” below for env overrides.
 - **Base64 validation**: Strict validation with canonical form checking to prevent malformed input.
 - **Docker**: Image runs as non-root user `app:app` with `HEALTHCHECK` for container orchestration.
+
+### Error payload size knobs (optional)
+
+The sanitizer trims large or circular structures before emitting JSON. You can adjust the bounds via env vars (values are clamped to safe ranges):
+
+- `ERROR_MAX_STRING` (default `2000`)
+- `ERROR_MAX_ENTRIES` (default `20`)
+- `ERROR_MAX_ARRAY_ITEMS` (default `20`)
+- `ERROR_MAX_DEPTH` (default `3`)
 
 ## Acceptance Criteria
 

--- a/services/ocr-webhook/tests/openai-preslice-large.test.ts
+++ b/services/ocr-webhook/tests/openai-preslice-large.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+const LARGE_BUFFER = Buffer.alloc(6_219_172, 1);
+const LARGE_BASE64 = LARGE_BUFFER.toString("base64");
+
+const presliceMock = vi.fn();
+const openAiCreateMock = vi.fn();
+
+vi.mock("../preslice.js", () => ({
+  preslicePdfToPngBuffers: presliceMock
+}));
+
+vi.mock("openai", () => {
+  return {
+    default: class MockOpenAI {
+      constructor() {
+        this.responses = { create: openAiCreateMock };
+      }
+    }
+  };
+});
+
+import app from "../server.js";
+
+const ENV_KEYS = [
+  "NODE_ENV",
+  "LOG_LEVEL",
+  "OPENAI_API_KEY",
+  "PDF_PRESLICE",
+  "PRESLICE_DPI",
+  "PRESLICE_MAX_PAGES",
+  "PRESLICE_MAX_OUTPUT_MB",
+  "AZURE_VISION_ENDPOINT",
+  "AZURE_VISION_KEY"
+];
+
+const ORIGINAL_ENV = Object.fromEntries(ENV_KEYS.map(key => [key, process.env[key]]));
+
+afterAll(() => {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (typeof value === "undefined") {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+beforeEach(() => {
+  presliceMock.mockReset();
+  openAiCreateMock.mockReset();
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+  process.env.NODE_ENV = "test";
+  process.env.LOG_LEVEL = "silent";
+  process.env.OPENAI_API_KEY = "sk-test";
+  process.env.PDF_PRESLICE = "1";
+  process.env.PRESLICE_DPI = "96";
+  process.env.PRESLICE_MAX_PAGES = "5";
+  process.env.PRESLICE_MAX_OUTPUT_MB = "64";
+});
+
+describe("OpenAI preslice handling for large PDFs", () => {
+  it("processes large base64 payloads with languages hint", async () => {
+    presliceMock.mockResolvedValue([Buffer.from("png1"), Buffer.from("png2")]);
+    let call = 0;
+    openAiCreateMock.mockImplementation(async () => ({ output_text: `page ${++call}` }));
+
+    const res = await request(app)
+      .post("/extract")
+      .set("Content-Type", "application/json")
+      .send({
+        mime: "application/pdf",
+        dataBase64: LARGE_BASE64,
+        languages: ["eng"],
+        maxPages: 3
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-request-id"]).toBeTruthy();
+    expect(res.body.meta?.engine).toBe("openai-vision");
+    expect(res.body.pagesOcred).toEqual([1, 2]);
+    expect(openAiCreateMock).toHaveBeenCalledTimes(2);
+    expect(presliceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns compact error payload when preslice fails with nested detail", async () => {
+    const err = new Error("preslice worker crashed");
+    err.status = 502;
+    err.code = "preslice_worker_failure";
+    err.detail = {
+      huge: Array.from({ length: 30 }, (_, i) => ({
+        index: i,
+        payload: { depth: { value: i } }
+      }))
+    };
+    presliceMock.mockRejectedValueOnce(err);
+
+    const res = await request(app)
+      .post("/extract")
+      .set("Content-Type", "application/json")
+      .send({
+        mime: "application/pdf",
+        dataBase64: LARGE_BASE64,
+        languages: ["eng"],
+        maxPages: 3
+      });
+
+    expect(res.status).toBe(502);
+    expect(res.body.error?.code).toBe("preslice_worker_failure");
+    expect(res.body.error?.message).toBe("preslice worker crashed");
+    expect(res.body.error?.requestId).toBeTruthy();
+    expect(() => JSON.stringify(res.body.error.detail)).not.toThrow();
+    expect(Array.isArray(res.body.error.detail?.huge)).toBe(true);
+    expect(res.body.error.detail.huge.length).toBeLessThanOrEqual(21);
+    expect(res.body.error.detail.huge.at(-1)).toContain("truncated");
+    expect(openAiCreateMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- O(n) base64 validator and sanitized error detail/meta handling
- wrap OpenAI page workers with try/catch to attach page-specific context
- add regression test covering large MCP-style OpenAI preslice payload

## Testing
- npm ci
- npm run lint
- npm test
- cd services/ocr-webhook && npm ci
- cd services/ocr-webhook && npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stricter file-size parsing (25 MB default), request-id included in error payloads, empty-PDF detection, and bounded page limits; per-page OCR errors are wrapped with page context and standardized formatting.

* **Bug Fixes**
  * Strict base64 validation with pre-decode size checks; improved error propagation and sanitization to truncate/safely represent binary or large structures.

* **Documentation**
  * Added error-sanitizer knobs and guidance for payload-size controls and expected endpoint behaviors.

* **Tests**
  * New tests covering large PDF preslice flows and multiple error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->